### PR TITLE
Add helper tasks and tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY . .
+RUN ./gradlew jvmJar --no-daemon -x jvmTest
+CMD ["java", "-jar", "build/libs/SolaceCore-jvm.jar"]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ git clone https://github.com/yourusername/SolaceCore.git
 cd SolaceCore
 ./gradlew build
 ```
+### Docker
+To build and run the project in a container:
+```bash
+docker build -t solacecore .
+docker run --rm solacecore
+```
 
 ## Usage
 
@@ -145,6 +151,12 @@ Comprehensive documentation is available in the `docs/` directory:
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
+
+### Actor Template Generator
+A helper script is available in `tools/generate_actor.sh` to scaffold new actors:
+```bash
+./tools/generate_actor.sh MyActor
+```
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ The `docs` directory contains comprehensive documentation for the Solace Core Fr
   - **lifecycle/**: Documentation for the standardized approach to component lifecycle management
   - **workflow/**: Documentation for the workflow management system (planned)
 - **diagrams/**: Visual representations of the framework's architecture are located within the corresponding component folders
+- **examples/**: Usage snippets and small workflows
+  - [Basic Actor Usage](examples/Basic_Actor_Usage.md)
   - [kernel/system_architecture.md](components/kernel/system_architecture.md): High-level overview of the system architecture
   - [actor_system/actor_system_class_diagram.md](components/actor_system/actor_system_class_diagram.md): Class structure of the actor system
   - [actor_system/actor_communication_sequence.md](components/actor_system/actor_communication_sequence.md): Sequence diagram showing actor interaction
@@ -24,6 +26,7 @@ The `docs` directory contains comprehensive documentation for the Solace Core Fr
   - [MASTER_CHECKLIST.md](MASTER_CHECKLIST.md): Consolidated project checklist
   - [STORAGE_CHECKLIST.md](STORAGE_CHECKLIST.md): Storage subsystem tasks
   - [Test_Coverage_Checklist.md](Test_Coverage_Checklist.md): Test coverage tracking
+- [SETUP.md](SETUP.md): Basic development setup
 
 ## Current Implementation Status
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,8 @@
+# Setup Instructions
+
+This guide provides a quick way to get a development environment running.
+
+1. Ensure JDK 17 or later and Gradle are installed.
+2. Clone the repository and run `./gradlew build`.
+3. To run all tests, execute `./gradlew jvmTest`.
+4. Optionally build a Docker image using the included Dockerfile.

--- a/docs/examples/Basic_Actor_Usage.md
+++ b/docs/examples/Basic_Actor_Usage.md
@@ -1,0 +1,20 @@
+# Basic Actor Usage Example
+
+The following example demonstrates creating a small actor and connecting it in a workflow.
+
+```kotlin
+class EchoActor : Actor() {
+    val input = InputPort<String>("input", String::class)
+    val output = OutputPort<String>("output", String::class)
+
+    override suspend fun process() {
+        val msg = input.receive()
+        output.send(msg)
+    }
+}
+
+val workflow = WorkflowBuilder()
+    .addActor("echo", EchoActor())
+    .build()
+workflow.start()
+```

--- a/task1.md
+++ b/task1.md
@@ -1,0 +1,5 @@
+# Task 1: Docker Containerization
+
+This task implements the basic containerization steps referenced in the master checklist.
+It adds a Dockerfile that builds the project jar and runs it using JDK 17.
+Documentation is updated with instructions to build and run the container.

--- a/task2.md
+++ b/task2.md
@@ -1,0 +1,4 @@
+# Task 2: Actor Template Generator
+
+A simple script under `tools/` allows generating a new actor source file based on a template.
+This helps with the checklist item _"Add actor template generators"_.

--- a/task3.md
+++ b/task3.md
@@ -1,0 +1,4 @@
+# Task 3: Component Usage Example
+
+This documentation file demonstrates how to create a very small actor and include it in a workflow.
+It addresses the checklist item to _"Add usage examples for each component."_

--- a/task4.md
+++ b/task4.md
@@ -1,0 +1,4 @@
+# Task 4: Setup Documentation
+
+Created a new `docs/SETUP.md` file with basic instructions for getting started.
+This supports the checklist item to _"Add detailed setup instructions."_

--- a/tools/generate_actor.sh
+++ b/tools/generate_actor.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Simple template generator for new actors.
+# Usage: ./generate_actor.sh MyActor
+
+name=$1
+if [ -z "$name" ]; then
+  echo "Usage: $0 ActorName" >&2
+  exit 1
+fi
+cat > "$name.kt" <<'TEMPLATE'
+package ai.solace.custom
+
+import ai.solace.core.actor.Actor
+
+class $name : Actor() {
+    override suspend fun process() {
+        // TODO: implement actor logic
+    }
+}
+TEMPLATE
+
+echo "Created $name.kt"
+


### PR DESCRIPTION
## Summary
- add Dockerfile for basic containerization
- document how to build Docker image and actor template generator in README
- link to setup instructions and examples in documentation
- add actor generator script and example doc
- add task files for new checklist items

## Testing
- `./gradlew jvmTest` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68883156b7188333b8f20c90fdecdca9