### PR TITLE
feat: add actor factory registration and automatic hot swapping

### DIFF
--- a/docs/components/actor_system/SupervisorActor.md
+++ b/docs/components/actor_system/SupervisorActor.md
@@ -6,6 +6,7 @@ The SupervisorActor is a specialized actor responsible for managing the lifecycl
 ## Features
 - **Dynamic Actor Registration**: Register and unregister actors at runtime
 - **Hot-Swapping**: Replace actors with new instances of the same type while preserving their connections
+- **Actor Factory Registration**: Register factories to create actors on demand and enable factory-based hot-swapping
 - **Type-Safe Actor Management**: Ensure that actors are only replaced with compatible types
 - **Thread-Safe Operations**: All operations are synchronized using a mutex to prevent race conditions
 - **Lifecycle Management**: Start and stop all managed actors as a group
@@ -54,6 +55,18 @@ if (swapped) {
 } else {
     println("Failed to hot-swap actor (not found or incompatible type)")
 }
+```
+
+### Registering Actor Factories and Hot-Swapping Automatically
+```kotlin
+// Register a factory for MyActor
+supervisor.registerActorFactory(MyActor::class) { MyActor() }
+
+// Create and register an actor using the factory
+val actor = supervisor.createAndRegisterActor(MyActor::class)
+
+// Hot-swap the actor using the registered factory
+val swapped = supervisor.hotSwapActor(actor.id)
 ```
 
 ### Managing Actor Lifecycles

--- a/lib/src/jvmTest/kotlin/ai/solace/core/actor/supervisor/SupervisorActorTest.kt
+++ b/lib/src/jvmTest/kotlin/ai/solace/core/actor/supervisor/SupervisorActorTest.kt
@@ -185,6 +185,38 @@ class SupervisorActorTest {
     }
 
     @Test
+    fun testCreateAndRegisterActorFromFactory() = runTest {
+        val supervisor = SupervisorActor()
+        supervisor.start()
+
+        supervisor.registerActorFactory(TestActor::class) { TestActor() }
+
+        val actor = supervisor.createAndRegisterActor(TestActor::class)
+        val retrieved = supervisor.getActor(actor.id)
+        assertNotNull(retrieved)
+        assertEquals(actor.id, retrieved.id)
+    }
+
+    @Test
+    fun testHotSwapActorUsingFactory() = runTest {
+        val supervisor = SupervisorActor()
+        supervisor.start()
+
+        supervisor.registerActorFactory(TestActor::class) { TestActor() }
+
+        val actor = supervisor.createAndRegisterActor(TestActor::class) as TestActor
+        actor.customState = "old"
+        actor.start()
+
+        val result = supervisor.hotSwapActor(actor.id)
+        assertTrue(result)
+
+        val swapped = supervisor.getActor(actor.id) as TestActor
+        assertEquals(ActorState.Running, swapped.state)
+        assertEquals("initial", swapped.customState)
+    }
+
+    @Test
     fun testGetActorsByType() = runTest {
         val supervisor = SupervisorActor()
         val actor1 = TestActor()


### PR DESCRIPTION
## Summary
- allow SupervisorActor to register factories for actor types
- enable dynamic creation of actors and factory-based hot-swapping
- document factory registration and add tests for new workflow

## Testing
- `./gradlew jvmTest`


------
https://chatgpt.com/codex/tasks/task_e_68baabe257408333835f0750333fce8c