### PR TITLE
Enhance web compose experience

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -1,20 +1,54 @@
 package org.solace.composeapp
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import org.solace.composeapp.ui.components.*
 import org.solace.composeapp.ui.service.RealTimeActorService
+import org.solace.composeapp.ui.theme.SolaceTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun App() {
-    MaterialTheme {
-        SolaceRealTimeUI()
+    SolaceTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                                MaterialTheme.colorScheme.background
+                            )
+                        )
+                    )
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .fillMaxSize()
+                        .widthIn(max = 1320.dp),
+                    tonalElevation = 4.dp,
+                    shadowElevation = 16.dp,
+                    shape = MaterialTheme.shapes.large,
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)
+                ) {
+                    SolaceRealTimeUI()
+                }
+            }
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/solace/composeapp/ui/theme/SolaceTheme.kt
+++ b/composeApp/src/commonMain/kotlin/org/solace/composeapp/ui/theme/SolaceTheme.kt
@@ -1,0 +1,42 @@
+package org.solace.composeapp.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val SolaceDarkColorScheme = darkColorScheme(
+    primary = Color(0xFF38BDF8),
+    onPrimary = Color(0xFF001C2C),
+    primaryContainer = Color(0xFF0F172A),
+    onPrimaryContainer = Color(0xFFD6F4FF),
+    secondary = Color(0xFF6366F1),
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFF1E1B4B),
+    onSecondaryContainer = Color(0xFFE0E7FF),
+    tertiary = Color(0xFF22D3EE),
+    onTertiary = Color(0xFF002022),
+    background = Color(0xFF020817),
+    onBackground = Color(0xFFE2E8F0),
+    surface = Color(0xFF0F172A),
+    onSurface = Color(0xFFE2E8F0),
+    surfaceVariant = Color(0xFF1E293B),
+    onSurfaceVariant = Color(0xFFCBD5F5),
+    error = Color(0xFFF87171),
+    onError = Color(0xFF410002)
+)
+
+private val SolaceTypography = Typography()
+private val SolaceShapes = Shapes()
+
+@Composable
+fun SolaceTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = SolaceDarkColorScheme,
+        typography = SolaceTypography,
+        shapes = SolaceShapes,
+        content = content
+    )
+}

--- a/composeApp/src/desktopMain/kotlin/Platform.kt
+++ b/composeApp/src/desktopMain/kotlin/Platform.kt
@@ -1,6 +1,6 @@
 package org.solace.composeapp
 
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 
 @Composable

--- a/composeApp/src/webMain/kotlin/Platform.kt
+++ b/composeApp/src/webMain/kotlin/Platform.kt
@@ -1,7 +1,7 @@
 package org.solace.composeapp
 
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import org.jetbrains.compose.web.dom.Text
 
 @Composable
 actual fun PlatformText(text: String) {

--- a/composeApp/src/webMain/kotlin/main.kt
+++ b/composeApp/src/webMain/kotlin/main.kt
@@ -1,9 +1,11 @@
 package org.solace.composeapp
 
-import org.jetbrains.compose.web.renderComposable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.CanvasBasedWindow
 
+@OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-    renderComposable(rootElementId = "root") {
+    CanvasBasedWindow(title = "SolaceCore Monitor") {
         App()
     }
 }

--- a/composeApp/src/webMain/resources/index.html
+++ b/composeApp/src/webMain/resources/index.html
@@ -2,7 +2,31 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Solace Compose</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SolaceCore Monitor</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        html, body {
+            margin: 0;
+            height: 100%;
+            background: radial-gradient(circle at top left, #1f2937 0%, #020617 55%);
+            color: #e2e8f0;
+            font-family: 'Inter', sans-serif;
+        }
+
+        #root {
+            width: 100%;
+            height: 100%;
+        }
+
+        canvas {
+            width: 100% !important;
+            height: 100% !important;
+            outline: none;
+        }
+    </style>
 </head>
 <body>
 <div id="root"></div>


### PR DESCRIPTION
## Summary
- introduce a shared SolaceTheme with a dark color palette to unify desktop and web styling
- wrap the app surface with gradient-backed containers for a richer web presentation and Material3 text plumbing
- switch the web entrypoint to CanvasBasedWindow and refresh the HTML shell with fonts and responsive defaults

## Testing
- `./gradlew :composeApp:compileKotlinWeb --console=plain`
- `./gradlew :composeApp:webBrowserDistribution --console=plain` *(fails: JavaScript backend OOM while lowering Compose semantics)*

------
https://chatgpt.com/codex/tasks/task_e_68d64a70025883339a0aebca1b22ae97