### PR TITLE
CodeQL: fix Gradle autobuild

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,10 +44,11 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # For Kotlin/Java projects, autobuild should work
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+    # CodeQL's autobuild assumes a Java-style `testClasses` task, but this repo is
+    # Gradle Kotlin Multiplatform and exposes per-target/per-module *TestClasses tasks.
+    # Build the JVM targets explicitly so the Java/Kotlin extractor has bytecode.
+    - name: Build (Gradle)
+      run: ./gradlew --no-daemon :lib:jvmTestClasses :composeApp:desktopTestClasses
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL autobuild runs `./gradlew testClasses`, but this KMP repo only has per-module/per-target *TestClasses tasks. Run the JVM builds explicitly so the Java/Kotlin extractor can proceed.