### PR TITLE
core.mood: emotional advisor contract + lexical baseline

### DIFF
--- a/docs/components/mood/README.md
+++ b/docs/components/mood/README.md
@@ -1,0 +1,110 @@
+# Mood — affective signal as the memory-indexing primitive
+
+> Status: foundation **shipped** under `core.mood` (cue surface, advisor contract, lexical advisor). Spike-train signature, LTC integration, and arousal-modulated retrieval are **designed**, not yet built.
+
+## Why mood is in the kernel
+
+Most AI assistants treat emotion as decoration — a tone slider on the output, maybe a "be empathetic" line in the system prompt. SolaceCore takes the opposite position: **emotion is structural**. It is the index over memory.
+
+The architectural argument:
+
+1. **Human memory does not match by lexical similarity.** It matches by *affective contour*. A current moment that feels like a past moment surfaces that past moment, even when the surface words are completely different.
+2. **A spike train through an integrate-and-fire substrate produces a sparse, time-structured signature** that captures that contour. A Liquid Time-Constant cell integrates that signature into a continuous-time hidden state.
+3. **That hidden state, at the moment a Reflection Memory entry is written, *is* the affective fingerprint of the entry.** Retrieval is signature correlation, not embedding cosine.
+4. **Mood cues are the structured handle on this primitive** — typed messages produced by advisor actors and consumed by the executive supervisor and (eventually) the signature layer.
+
+This is what makes SolaceCore different from a RAG-flavored chat system. The mood module is the entry point to that difference.
+
+For the broader Solace narrative-management framing — Reflection Memory, Mouth Tool, Confusion Corrector, Time Awareness, Zoom Controller — see [`../memory/MemoryToolDesign.md`](../memory/MemoryToolDesign.md) (the SRAF design). For the Liquid + Transformer hybrid that produces the integrated signatures, see [`../actor_inference_engine/InferenceCubeArchitecture.md`](../actor_inference_engine/InferenceCubeArchitecture.md) and the [Kaggle proof notebook](../actor_inference_engine/liquid-neural-networks-hybrid-transformer.ipynb).
+
+## Where mood sits in the three-tier hybrid
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  TRANSFORMER / LLM — Supervisor (executive cognition)       │
+│  Reads Reflection Memory; weighs MoodCues; decides          │
+│  Emits utterances via the Mouth Tool                        │
+└───────────▲─────────────────────────────────────────────────┘
+            │ context-prime: cues, replay summaries, signatures
+            │
+┌───────────┴─────────────────────────────────────────────────┐
+│  LIQUID LAYER — LTC continuous-time integration             │
+│  Inherits transformer behavior cube-by-cube (InferenceCube) │
+│  Hidden state at write-time = affective signature           │
+└───────────▲─────────────────────────────────────────────────┘
+            │ event-tagged temporal input
+            │
+┌───────────┴─────────────────────────────────────────────────┐
+│  SPIKING LAYER — sparse event-driven affective markers      │
+│  Fires on salience: emotional valence, novelty, change      │
+│  Stamps every Reflection Memory entry with a signature      │
+└───────────▲─────────────────────────────────────────────────┘
+            │ raw signal
+       ┌────┴───────────────────────────────────────┐
+       │  EMOTIONAL ADVISORS (this module today)     │
+       │  Read user input + advisor cues             │
+       │  Emit structured MoodCue messages           │
+       │  Lexical baseline ships now; spike-based    │
+       │  classifier replaces it later               │
+       └─────────────────────────────────────────────┘
+```
+
+The advisor layer is the **structured handle** the executive uses to reason about emotion. The spike + liquid layers below it are how memory gets indexed by affect, but the executive doesn't need to wait for those layers to land — it can already weigh `MoodCue` messages today.
+
+## Public surface (shipped under `io.github.solaceharmony.core.mood`)
+
+| Type | Role |
+|---|---|
+| `Emotion` | Enum class. Discrete affective categories (`JOY`, `CALM`, `CURIOSITY`, `FRUSTRATION`, `ANGER`, `SADNESS`, `FEAR`, `SURPRISE`, `NEUTRAL`). Each entry carries a lower-case `label` for prompt-prime use. |
+| `MoodCue` | Structured cue message. Fields: `correlationId`, `timestamp`, `source` (advisor name), `emotion`, `intensity` (0..1), `confidence` (0..1), optional `promptSuggestion`, optional `evidence` (text fragments that support the classification). |
+| `MoodSignature` | Interface for an affective fingerprint. `dimensions: Int`, `correlate(other: MoodSignature): Float`. The actual signature implementation lives in the spike + liquid layers (not yet shipped); the interface is shipped now so consumers can program against it. |
+| `EmotionalAdvisor` | Abstract `Actor` base. Owns input port `userText` (consumes `String`) and output port `cues` (emits `MoodCue`). Subclasses implement `analyze(text)`. |
+| `Lexicon` | Pluggable keyword lexicon: `Map<Emotion, List<Regex>>`. |
+| `LexicalEmotionalAdvisor` | Concrete advisor that scores emotions by keyword/regex matches against a `Lexicon`. Working baseline; intentionally simple. |
+| `LexicalEmotionalAdvisor.DEFAULT_LEXICON` | A small, principled lexicon shipping with the advisor. |
+
+## Why ship a lexical baseline first
+
+Affective classification is a deep research area. The spike + liquid pipeline is the long-term answer, but it requires the InferenceCube state machine to land first. Meanwhile, the executive needs *something* to consume — and a lexical sentiment classifier, while crude, captures enough signal to:
+
+- Validate the cue protocol end-to-end (advisor → port → supervisor consumption).
+- Demonstrate the actor topology the spike-based advisor will eventually slot into.
+- Give downstream consumers (Mouth Tool framing, ReflectionMemory tagging) a real producer to wire against.
+
+When the spike-based advisor lands, the seam is clear: replace `LexicalEmotionalAdvisor` with `SpikingEmotionalAdvisor` in the actor graph, leave every consumer of `MoodCue` untouched.
+
+## What's designed but not yet built
+
+- **`SpikingEmotionalAdvisor`** — integrate-and-fire substrate that produces sparse spike trains rather than discrete cues. Cues become a coarser projection of the underlying spike signature.
+- **`LTCSignatureExtractor`** — wraps an LTC cell (per [InferenceCube](../actor_inference_engine/InferenceCubeArchitecture.md)) so the cell's hidden state at write-time can be retrieved as a `MoodSignature` for stamping a Reflection Memory entry.
+- **`SignatureCorrelator`** — the retrieval primitive. Given a current `MoodSignature` and a freshness window, returns Reflection Memory entries whose stored signature correlates above threshold.
+- **`MoodTracker`** — running-state actor that integrates `MoodCue`s over time, exposes a "current affective state" snapshot that other advisors can read (e.g., to detect mood-change events for the time/zoom controllers).
+- **Cross-modal advisors** — vision, audio, biometric. Each emits its own `MoodCue` stream; the supervisor weighs the cross-modal evidence.
+
+These all slot into the same actor topology this module ships today. The advisor contract is the load-bearing seam.
+
+## Failure modes the design takes seriously
+
+| Failure | Mitigation |
+|---|---|
+| Lexical advisor false positives flooding the supervisor | `confidence` threshold on the advisor; the supervisor can ignore low-confidence cues. |
+| Cue storms during emotionally-charged conversations | Token-bucket rate limiting at the advisor's output port; supervisor back-pressure. |
+| Mood cue "leaks" into user-facing output as if it were the user's voice | The Mouth Tool, not the supervisor, owns egress. Cues are origin-tagged and never appear in user-facing text directly. |
+| Multiple advisors disagree on classification | The supervisor decides. `MoodCue.confidence` and `MoodCue.evidence` are the inputs to that decision. |
+| Wrong language / cultural lexicon | Lexicons are pluggable; `LexicalEmotionalAdvisor` accepts a `Lexicon` parameter. The default is intentionally small and English-skewed; downstream deployments override. |
+
+## Privacy and policy
+
+Mood cues are **internal** signals. They are written to Reflection Memory tagged with `Origin.ADVISOR`, but they are not part of user-facing output. The Mouth Tool decides whether to acknowledge a mood cue in its response, never the cue itself.
+
+Sensitive emotional inferences (e.g., "user appears depressed") are still inferences. Persistence policy is set by the deployment, not the kernel:
+
+- Reflection Memory entries containing high-intensity/low-confidence cues should be flagged for review or auto-purge depending on policy.
+- The advisor's `evidence` field carries the raw text fragments that support the classification — useful for debugging, dangerous if exfiltrated. Deployments should redact or omit this field for production use.
+
+## See also
+
+- [`../memory/MemoryToolDesign.md`](../memory/MemoryToolDesign.md) — the SRAF narrative-management spec; covers the supervisor's decision loop and the Mouth Tool that owns egress.
+- [`../actor_inference_engine/InferenceCubeArchitecture.md`](../actor_inference_engine/InferenceCubeArchitecture.md) — the Liquid + Transformer hybrid this layer will integrate with.
+- [`../actor_inference_engine/liquid-neural-networks-hybrid-transformer.ipynb`](../actor_inference_engine/liquid-neural-networks-hybrid-transformer.ipynb) — Kaggle proof of the LTC + attention composition.
+- [`../actor_system/SupervisorAI_EmotionalModel.md`](../actor_system/SupervisorAI_EmotionalModel.md) — the older sketch of the executive-emotional integration; this module is the concrete shipped subset.

--- a/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/Emotion.kt
+++ b/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/Emotion.kt
@@ -1,0 +1,58 @@
+package io.github.solaceharmony.core.mood
+
+/**
+ * A discrete affective category produced by an [EmotionalAdvisor].
+ *
+ * Solace treats emotion as a structured signal, not a tone modifier. Discrete
+ * categories are the *coarse* surface that the executive supervisor reasons
+ * over; the underlying signature (spike train + LTC hidden state) is the
+ * *fine-grained* index over Reflection Memory. The two layers are deliberate:
+ * the discrete categories are what an LLM can talk about, the signature is
+ * what biological retrieval rhymes against.
+ *
+ * The set is intentionally small and principled. Lexicons can map many
+ * surface words onto each category; the category itself is the contract
+ * with the supervisor.
+ *
+ * For the design rationale see [`docs/components/mood/README.md`](../../../../../../../../../docs/components/mood/README.md).
+ *
+ * @property label Human-readable label for logging and prompt-prime construction.
+ */
+enum class Emotion(val label: String) {
+    /** Positive valence. Lightness, warmth, satisfaction. */
+    JOY("joy"),
+
+    /** Low arousal, positive valence. Steadiness; ground state. */
+    CALM("calm"),
+
+    /** Engaged attention. Wanting to know. */
+    CURIOSITY("curiosity"),
+
+    /** Negative valence with stuck-ness. The "I keep trying and it isn't working" signal. */
+    FRUSTRATION("frustration"),
+
+    /** High arousal, negative valence, externally directed. */
+    ANGER("anger"),
+
+    /** Low arousal, negative valence. Loss, withdrawal. */
+    SADNESS("sadness"),
+
+    /** High arousal, negative valence, anticipatory. */
+    FEAR("fear"),
+
+    /** Sudden discrepancy from expectation. Valence-neutral on its own. */
+    SURPRISE("surprise"),
+
+    /** No detectable affect or signal below the advisor's confidence threshold. */
+    NEUTRAL("neutral");
+
+    companion object {
+        /**
+         * The non-Neutral emotions, in a stable order suitable for iteration
+         * (e.g., for scoring loops in advisors that consider every category).
+         */
+        val ALL_NON_NEUTRAL: List<Emotion> = listOf(
+            JOY, CALM, CURIOSITY, FRUSTRATION, ANGER, SADNESS, FEAR, SURPRISE,
+        )
+    }
+}

--- a/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/EmotionalAdvisor.kt
+++ b/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/EmotionalAdvisor.kt
@@ -1,0 +1,101 @@
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+package io.github.solaceharmony.core.mood
+
+import io.github.solaceharmony.core.actor.Actor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.uuid.Uuid
+
+/**
+ * Abstract base for actors that consume text input and emit [MoodCue]s.
+ *
+ * The contract is intentionally narrow: `analyze(text)` returns a single
+ * cue (or `null` for "nothing to say"). Subclasses can vary wildly in how
+ * they classify — a keyword lexicon, a remote sentiment API, a small
+ * on-device model, an integrate-and-fire spike net — but every advisor
+ * speaks the same protocol back to the supervisor.
+ *
+ * The actor owns two ports:
+ *
+ * | Port name | Direction | Type |
+ * |-----------|-----------|------|
+ * | [INPUT_PORT] | input  | `String` (the user text or other advisor cue text) |
+ * | [OUTPUT_PORT] | output | `MoodCue` (analysis result, when not null) |
+ *
+ * Multiple advisors typically run in parallel as siblings under the
+ * supervisor's coroutine scope. When the supervisor cancels its scope,
+ * every advisor's input-handler coroutine is cancelled cleanly; the
+ * structured-concurrency invariant the SolaceCore actor system enforces
+ * is what makes this safe.
+ *
+ * @see io.github.solaceharmony.core.actor.Actor for the underlying actor
+ *   contract this base extends.
+ */
+abstract class EmotionalAdvisor(
+    id: String = Uuid.random().toString(),
+    name: String = "EmotionalAdvisor",
+    scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+) : Actor(id, name, scope) {
+
+    companion object {
+        /** Name of the input port that consumes user/advisor text. */
+        const val INPUT_PORT: String = "userText"
+
+        /** Name of the output port that emits classified cues. */
+        const val OUTPUT_PORT: String = "cues"
+    }
+
+    /**
+     * Analyse the given input and produce a [MoodCue], or `null` if there
+     * is nothing meaningful to emit (e.g. the input fell below the
+     * advisor's confidence threshold and the advisor prefers silence over
+     * emitting a `Neutral` cue).
+     *
+     * Implementations are free to be slow or asynchronous; the actor
+     * runtime serializes calls per port and applies a per-message
+     * processing timeout configured at port-creation time.
+     */
+    abstract suspend fun analyze(text: String): MoodCue?
+
+    /**
+     * Initializes the advisor's input and output ports. Idempotent —
+     * safe to call multiple times. Subclasses that override [start] to
+     * add their own bring-up should still call this (or `super.start()`)
+     * before using the ports.
+     */
+    suspend fun initialize() {
+        if (getPort(INPUT_PORT, String::class) == null) {
+            createPort(
+                name = INPUT_PORT,
+                messageClass = String::class,
+                handler = { text -> handleInput(text) },
+                bufferSize = 16,
+            )
+        }
+        if (getPort(OUTPUT_PORT, MoodCue::class) == null) {
+            createOutputPort(
+                name = OUTPUT_PORT,
+                messageClass = MoodCue::class,
+                bufferSize = 16,
+            )
+        }
+    }
+
+    /**
+     * Default consumer for the input port: invoke [analyze] and forward a
+     * non-null cue to the output port. Subclasses can override to add
+     * pre/post-processing (e.g., trimming evidence, applying a deployment-
+     * specific redaction policy) but should typically delegate the actual
+     * classification to [analyze].
+     */
+    protected open suspend fun handleInput(text: String) {
+        val cue = analyze(text) ?: return
+        getPort(OUTPUT_PORT, MoodCue::class)?.send(cue)
+    }
+
+    override suspend fun start() {
+        initialize()
+        super.start()
+    }
+}

--- a/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/LexicalEmotionalAdvisor.kt
+++ b/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/LexicalEmotionalAdvisor.kt
@@ -1,0 +1,163 @@
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+package io.github.solaceharmony.core.mood
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.uuid.Uuid
+
+/**
+ * A baseline [EmotionalAdvisor] that scores emotions by keyword/regex
+ * matches against a [Lexicon].
+ *
+ * This is intentionally simple. Lexical sentiment classification is well-
+ * known to miss sarcasm, negation, cultural variance, and almost every
+ * subtlety humans care about. It ships not because it's the right
+ * long-term answer but because:
+ *
+ * 1. It validates the cue protocol end-to-end (advisor → port →
+ *    supervisor).
+ * 2. It demonstrates the actor topology a future spike-based advisor will
+ *    slot into.
+ * 3. It lets downstream consumers (Mouth Tool framing, Reflection Memory
+ *    tagging) wire against a real producer today.
+ *
+ * When a stronger advisor lands (a small on-device classifier, an
+ * integrate-and-fire spike net, an LLM-backed classifier), it can replace
+ * this advisor in the actor graph with no change to consumers.
+ *
+ * @param lexicon The keyword/regex lexicon used for scoring. Defaults to
+ *   [DEFAULT_LEXICON] (small, English-only, intentionally rough).
+ * @param confidenceThreshold Cues are emitted only when the advisor's
+ *   computed confidence meets or exceeds this value. Below the threshold
+ *   the advisor stays silent rather than emitting a `Neutral` cue. Range
+ *   `[0, 1]`. Defaults to `0.4`.
+ * @param maxEvidenceFragments Maximum number of matched fragments to
+ *   include in [MoodCue.evidence] for debugging. Set to `0` to omit
+ *   evidence entirely (recommended for production deployments).
+ */
+class LexicalEmotionalAdvisor(
+    private val lexicon: Lexicon = DEFAULT_LEXICON,
+    private val confidenceThreshold: Float = 0.4f,
+    private val maxEvidenceFragments: Int = 5,
+    id: String = Uuid.random().toString(),
+    name: String = "LexicalEmotionalAdvisor",
+    scope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
+) : EmotionalAdvisor(id, name, scope) {
+
+    init {
+        require(confidenceThreshold in 0f..1f) {
+            "confidenceThreshold must be in [0, 1], got $confidenceThreshold"
+        }
+        require(maxEvidenceFragments >= 0) {
+            "maxEvidenceFragments must be non-negative, got $maxEvidenceFragments"
+        }
+    }
+
+    override suspend fun analyze(text: String): MoodCue? {
+        if (text.isBlank()) return null
+
+        // Score every non-Neutral emotion by summing match weights.
+        // Track the matched fragments for evidence.
+        val scores = mutableMapOf<Emotion, Float>()
+        val fragments = mutableMapOf<Emotion, MutableList<String>>()
+
+        for (emotion in Emotion.ALL_NON_NEUTRAL) {
+            val patterns = lexicon.entries[emotion] ?: continue
+            for (wp in patterns) {
+                wp.regex.findAll(text).forEach { match ->
+                    scores[emotion] = (scores[emotion] ?: 0f) + wp.weight
+                    fragments.getOrPut(emotion) { mutableListOf() }.add(match.value)
+                }
+            }
+        }
+
+        if (scores.isEmpty()) return null
+
+        // Pick the top-scoring emotion. Compute intensity as the
+        // top score normalized by total score across categories
+        // (so a tied two-way classification gives intensity ~0.5
+        // for the winner). Compute confidence as the margin between
+        // the top and second-best scores.
+        val total = scores.values.sum()
+        val ranked = scores.entries.sortedByDescending { it.value }
+        val winner = ranked.first()
+        val runnerUp = ranked.drop(1).firstOrNull()?.value ?: 0f
+
+        val intensity = (winner.value / total).coerceIn(0f, 1f)
+        val confidence = ((winner.value - runnerUp) / total).coerceIn(0f, 1f)
+
+        if (confidence < confidenceThreshold) return null
+
+        val evidence = if (maxEvidenceFragments == 0) {
+            emptyList()
+        } else {
+            fragments[winner.key].orEmpty().take(maxEvidenceFragments)
+        }
+
+        return MoodCue(
+            source = name,
+            emotion = winner.key,
+            intensity = intensity,
+            confidence = confidence,
+            evidence = evidence,
+            promptSuggestion = winner.key.suggestion(),
+        )
+    }
+
+    private fun Emotion.suggestion(): String? = when (this) {
+        Emotion.FRUSTRATION -> "user appears frustrated; prioritise empathy and concrete next steps"
+        Emotion.ANGER -> "user is expressing anger; acknowledge before proposing solutions"
+        Emotion.SADNESS -> "user seems low; soften tone, validate before advising"
+        Emotion.FEAR -> "user expresses concern; reassure with specifics, avoid hedging"
+        Emotion.JOY -> "user is positive; match the energy briefly, stay focused"
+        Emotion.CURIOSITY -> "user is engaged; depth is welcome"
+        Emotion.SURPRISE -> "user noticed something unexpected; clarify whether it's a problem"
+        Emotion.CALM, Emotion.NEUTRAL -> null
+    }
+
+    companion object {
+        /**
+         * A small, principled English-only baseline lexicon. Tuned for
+         * clarity over recall. Production deployments should override.
+         */
+        val DEFAULT_LEXICON: Lexicon = Lexicon.fromKeywords(
+            mapOf(
+                Emotion.JOY to listOf(
+                    "\\bhappy\\b", "\\bglad\\b", "\\blove(d|s)?\\b", "\\bgreat\\b",
+                    "\\bawesome\\b", "\\bperfect\\b", "\\bthank you\\b", "\\bthanks\\b",
+                    "\\byay\\b", "🎉",
+                ),
+                Emotion.CALM to listOf(
+                    "\\bcalm\\b", "\\bok(ay)?\\b", "\\bfine\\b", "\\balright\\b",
+                    "\\bsteady\\b", "\\bquiet\\b",
+                ),
+                Emotion.CURIOSITY to listOf(
+                    "\\bcurious\\b", "\\bwhy\\b", "\\bhow does\\b", "\\bwondering\\b",
+                    "\\bwhat if\\b", "\\binteresting\\b",
+                ),
+                Emotion.FRUSTRATION to listOf(
+                    "\\bfrustrat(ing|ed)\\b", "\\bstuck\\b", "\\bwhy (does|won'?t|isn'?t)\\b",
+                    "\\bnot working\\b", "\\bkeeps? failing\\b", "\\bagain\\b",
+                    "\\b(dammit|damn it|wtf)\\b", "\\bstupid\\b",
+                ),
+                Emotion.ANGER to listOf(
+                    "\\b(angry|mad|furious)\\b", "\\bhate(d|s)?\\b", "\\bunacceptable\\b",
+                    "\\b(this is|that'?s) ridiculous\\b",
+                ),
+                Emotion.SADNESS to listOf(
+                    "\\b(sad|depressed|down|blue|miserable)\\b", "\\bcry(ing)?\\b",
+                    "\\bgrief(ing)?\\b", "\\blonely\\b", "\\btired\\b", "\\bexhausted\\b",
+                ),
+                Emotion.FEAR to listOf(
+                    "\\b(afraid|scared|worried|anxious|nervous)\\b",
+                    "\\b(panic|panicking)\\b", "\\bdread\\b",
+                ),
+                Emotion.SURPRISE to listOf(
+                    "\\b(wait|huh|what)\\b\\??", "\\b(no way|seriously)\\b",
+                    "\\bunexpected\\b", "\\bsuddenly\\b", "\\bweird\\b",
+                ),
+            )
+        )
+    }
+}

--- a/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/Lexicon.kt
+++ b/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/Lexicon.kt
@@ -1,0 +1,52 @@
+package io.github.solaceharmony.core.mood
+
+/**
+ * A pluggable mapping from [Emotion] to keyword/regex patterns that
+ * surface that emotion in text.
+ *
+ * Lexicons are intentionally simple: a list of regexes per emotion, each
+ * with an optional weight. The advisor scores an input by counting
+ * (weighted) matches per emotion, then picks the top scorer.
+ *
+ * The default English lexicon shipped under [LexicalEmotionalAdvisor.DEFAULT_LEXICON]
+ * is small, tuned for clarity, and English-only. Production deployments
+ * should replace it with one tuned to their domain and language.
+ *
+ * @property entries For each emotion, the list of weighted regex patterns
+ *   that signal it. Each pattern is treated as case-insensitive by
+ *   convention (the advisor lowercases input before matching), so
+ *   patterns should generally be written in lowercase.
+ */
+data class Lexicon(
+    val entries: Map<Emotion, List<WeightedPattern>>,
+) {
+    /**
+     * A single regex pattern with a positive weight indicating how
+     * strongly a match signals the associated emotion. Weights are
+     * unbounded but typically in `[0.5, 2.0]`. Higher-weighted matches
+     * dominate the scoring.
+     */
+    data class WeightedPattern(
+        val regex: Regex,
+        val weight: Float = 1.0f,
+    ) {
+        init {
+            require(weight > 0f) { "weight must be positive, got $weight" }
+        }
+    }
+
+    companion object {
+        /**
+         * Convenience constructor that takes plain strings and compiles
+         * them as case-insensitive regexes with weight 1.0.
+         */
+        fun fromKeywords(entries: Map<Emotion, List<String>>): Lexicon =
+            Lexicon(
+                entries = entries.mapValues { (_, keywords) ->
+                    keywords.map { kw ->
+                        WeightedPattern(Regex(kw, RegexOption.IGNORE_CASE))
+                    }
+                },
+            )
+    }
+}

--- a/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/MoodCue.kt
+++ b/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/MoodCue.kt
@@ -1,0 +1,58 @@
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+package io.github.solaceharmony.core.mood
+
+import kotlinx.datetime.Clock
+import kotlin.uuid.Uuid
+
+/**
+ * A structured affective cue produced by an [EmotionalAdvisor] and consumed
+ * by the executive supervisor (the LLM).
+ *
+ * `MoodCue` is the *typed* handle on emotion. It is what the supervisor sees
+ * when it reasons about how the user is feeling, what tone to take, whether
+ * to escalate empathy, whether to slow down. The cue is advisory — the
+ * supervisor decides whether to weigh it, ignore it, or override it.
+ *
+ * Cues are written to Reflection Memory tagged with `Origin.ADVISOR` (the
+ * Reflection Memory abstraction itself is designed but not yet shipped; see
+ * [`docs/components/memory/MemoryToolDesign.md`](../../../../../../../../../docs/components/memory/MemoryToolDesign.md)).
+ * They are *internal* signals; user-facing output goes through the Mouth Tool,
+ * not directly through the supervisor's interpretation of cues.
+ *
+ * @property correlationId Identifier linking this cue back to the input that
+ *   triggered it (typically the [io.github.solaceharmony.core.actor.ActorMessage.correlationId]
+ *   of the user's message). Lets the supervisor tie cues to their cause.
+ * @property timestamp When the cue was produced, in epoch milliseconds.
+ * @property source The advisor that produced this cue (e.g. `"lexical"`,
+ *   `"spiking"`, `"audio-tone"`). Multiple advisors may emit cues for the
+ *   same input; the supervisor compares them.
+ * @property emotion The discrete category. See [Emotion].
+ * @property intensity How strong the affect is, in `[0, 1]`. A faint
+ *   irritation might be `0.2`; a clearly angry message might be `0.9`.
+ * @property confidence How sure the advisor is about the classification, in
+ *   `[0, 1]`. The supervisor should weight cues by `confidence`; a high-
+ *   intensity, low-confidence cue is *less* reliable than a moderate-
+ *   intensity, high-confidence one.
+ * @property promptSuggestion Optional natural-language hint the supervisor
+ *   may inline into its next prompt context (e.g. `"prioritise empathy"`).
+ *   The supervisor is free to ignore this field.
+ * @property evidence Optional text fragments that supported the
+ *   classification. Useful for debugging; deployments may redact this
+ *   field for production.
+ */
+data class MoodCue(
+    val correlationId: String = Uuid.random().toString(),
+    val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
+    val source: String,
+    val emotion: Emotion,
+    val intensity: Float,
+    val confidence: Float,
+    val promptSuggestion: String? = null,
+    val evidence: List<String> = emptyList(),
+) {
+    init {
+        require(intensity in 0f..1f) { "intensity must be in [0, 1], got $intensity" }
+        require(confidence in 0f..1f) { "confidence must be in [0, 1], got $confidence" }
+        require(source.isNotBlank()) { "source must be a non-blank advisor name" }
+    }
+}

--- a/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/MoodSignature.kt
+++ b/lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/MoodSignature.kt
@@ -1,0 +1,55 @@
+package io.github.solaceharmony.core.mood
+
+/**
+ * An affective fingerprint suitable for use as an index over Reflection
+ * Memory.
+ *
+ * In the three-tier hybrid this is the *fine-grained* counterpart to the
+ * coarse [MoodCue]. A signature captures the time-integrated affective
+ * contour of a moment in a way that supports correlation-based retrieval —
+ * "find past entries whose stored signature correlates with the current
+ * one within a freshness window." That mechanism is the core of how
+ * Solace memory rhymes rather than searches.
+ *
+ * The interface is shipped now so consumers can program against it.
+ * Concrete implementations live in the spike + liquid layers and are not
+ * yet shipped:
+ *
+ * - **Spiking signature** — a sparse vector of (neuron index, spike time,
+ *   weight) triples produced by an integrate-and-fire substrate. Captures
+ *   the contour of the moment at high temporal resolution.
+ * - **LTC hidden-state signature** — the dense hidden state of a Liquid
+ *   Time-Constant cell at write-time, integrating recent input under a
+ *   continuous-time gate. This is what the
+ *   [InferenceCube architecture](../../../../../../../../../docs/components/actor_inference_engine/InferenceCubeArchitecture.md)
+ *   produces inside each cube.
+ *
+ * Both implementations satisfy the same correlation contract, so the
+ * Reflection Memory retrieval path can stay the same as the cell layer
+ * matures.
+ */
+interface MoodSignature {
+    /**
+     * Number of dimensions in this signature. Two signatures are
+     * comparable via [correlate] only when their dimensions match.
+     */
+    val dimensions: Int
+
+    /**
+     * Compute the affective correlation between this signature and
+     * [other]. Returns a value in `[-1, 1]`, where:
+     *
+     * - `1` means the two signatures are identical contours (perfect rhyme).
+     * - `0` means they are uncorrelated.
+     * - `-1` means they are anti-correlated (opposing contours).
+     *
+     * The retrieval primitive is "find entries whose stored signature has
+     * `correlate(current) >= threshold` within a freshness window." A
+     * typical threshold for affective resonance is in `[0.6, 0.8]` —
+     * tunable per deployment.
+     *
+     * Implementations should throw [IllegalArgumentException] when
+     * [other.dimensions] does not match [dimensions].
+     */
+    fun correlate(other: MoodSignature): Float
+}

--- a/lib/src/jvmTest/kotlin/io/github/solaceharmony/core/mood/LexicalEmotionalAdvisorTest.kt
+++ b/lib/src/jvmTest/kotlin/io/github/solaceharmony/core/mood/LexicalEmotionalAdvisorTest.kt
@@ -1,0 +1,115 @@
+package io.github.solaceharmony.core.mood
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LexicalEmotionalAdvisorTest {
+
+    @Test
+    fun `analyze returns null on blank input`() = runTest {
+        val advisor = LexicalEmotionalAdvisor()
+        assertNull(advisor.analyze(""))
+        assertNull(advisor.analyze("   \n  "))
+    }
+
+    @Test
+    fun `analyze returns null when no lexicon match`() = runTest {
+        val advisor = LexicalEmotionalAdvisor()
+        // Pure noun-phrase with no affective vocabulary — shouldn't trigger.
+        assertNull(advisor.analyze("the green pencil sat on the desk"))
+    }
+
+    @Test
+    fun `frustration is detected`() = runTest {
+        val advisor = LexicalEmotionalAdvisor()
+        val cue = advisor.analyze("I'm so frustrated, this stupid thing keeps failing again")
+        assertNotNull(cue)
+        assertEquals(Emotion.FRUSTRATION, cue.emotion)
+        assertTrue(cue.confidence >= 0.4f, "confidence should clear threshold, got ${cue.confidence}")
+        assertTrue(cue.intensity > 0f, "intensity should be positive, got ${cue.intensity}")
+        assertTrue(cue.evidence.isNotEmpty(), "evidence should include matched fragments")
+        assertEquals("LexicalEmotionalAdvisor", cue.source)
+    }
+
+    @Test
+    fun `joy is detected`() = runTest {
+        val advisor = LexicalEmotionalAdvisor()
+        val cue = advisor.analyze("This is great! I love it, thank you so much!")
+        assertNotNull(cue)
+        assertEquals(Emotion.JOY, cue.emotion)
+    }
+
+    @Test
+    fun `sadness is detected`() = runTest {
+        val advisor = LexicalEmotionalAdvisor()
+        val cue = advisor.analyze("I'm just so tired and lonely lately, everything feels miserable")
+        assertNotNull(cue)
+        assertEquals(Emotion.SADNESS, cue.emotion)
+    }
+
+    @Test
+    fun `prompt suggestion accompanies non-neutral non-calm emotions`() = runTest {
+        val advisor = LexicalEmotionalAdvisor()
+        val cue = advisor.analyze("I'm afraid this won't work, I'm worried about it")
+        assertNotNull(cue)
+        assertEquals(Emotion.FEAR, cue.emotion)
+        assertNotNull(cue.promptSuggestion)
+    }
+
+    @Test
+    fun `low-confidence input below threshold returns null`() = runTest {
+        // High threshold, same lexicon. A genuinely ambiguous mixed signal
+        // should fall below the threshold and return silence rather than
+        // emit a low-confidence Neutral cue.
+        val advisor = LexicalEmotionalAdvisor(confidenceThreshold = 0.9f)
+        val cue = advisor.analyze("I am happy but also frustrated and a bit scared")
+        // Three categories with comparable scores → confidence margin is small.
+        // At 0.9 threshold, the advisor stays silent.
+        assertNull(cue)
+    }
+
+    @Test
+    fun `evidence is omitted when maxEvidenceFragments is zero`() = runTest {
+        val advisor = LexicalEmotionalAdvisor(maxEvidenceFragments = 0)
+        val cue = advisor.analyze("I'm so frustrated and stuck again")
+        assertNotNull(cue)
+        assertTrue(cue.evidence.isEmpty(), "evidence should be empty when maxEvidenceFragments=0")
+    }
+
+    @Test
+    fun `evidence is bounded by maxEvidenceFragments`() = runTest {
+        val advisor = LexicalEmotionalAdvisor(maxEvidenceFragments = 2)
+        // Many frustration triggers in one input.
+        val cue = advisor.analyze("frustrated frustrated stuck stuck again again not working")
+        assertNotNull(cue)
+        assertTrue(cue.evidence.size <= 2, "evidence should be bounded, got ${cue.evidence.size}")
+    }
+
+    @Test
+    fun `custom lexicon overrides default`() = runTest {
+        val customLexicon = Lexicon.fromKeywords(
+            mapOf(Emotion.CURIOSITY to listOf("\\bquark\\b", "\\bphoton\\b"))
+        )
+        val advisor = LexicalEmotionalAdvisor(
+            lexicon = customLexicon,
+            confidenceThreshold = 0.0f,  // accept anything
+        )
+        val cue = advisor.analyze("the photon and the quark walked into a bar")
+        assertNotNull(cue)
+        assertEquals(Emotion.CURIOSITY, cue.emotion)
+    }
+
+    @Test
+    fun `intensity is normalized when one category dominates`() = runTest {
+        val advisor = LexicalEmotionalAdvisor()
+        // Only frustration triggers, multiple times → high intensity.
+        val cue = advisor.analyze("frustrated and stuck and not working, this stupid thing")
+        assertNotNull(cue)
+        assertEquals(Emotion.FRUSTRATION, cue.emotion)
+        assertEquals(1.0f, cue.intensity, 0.001f)
+    }
+}


### PR DESCRIPTION
## Summary

Resurrects the mood-system design as a proper SolaceCore module, with shipped foundation code that backs the doc rather than describing a different system. The cognition layers above the kernel asked for an emotional-advisor surface; this PR ships the cue protocol and a working lexical baseline so consumers (Mouth Tool, Reflection Memory tagging, the supervisor) can wire against a real producer today.

## What's new

### `docs/components/mood/README.md`

The design doc. Covers:

- **Why mood is in the kernel** — emotion as the memory-indexing primitive, not decoration. The spike-train + LTC-hidden-state argument for why retrieval should *rhyme*, not search.
- **Where mood sits in the three-tier hybrid** — diagram showing advisors (today) → spiking layer → liquid layer → transformer/supervisor.
- **Public surface** — table of shipped types under `io.github.solaceharmony.core.mood`.
- **Why a lexical baseline first** — validates the cue protocol end-to-end, demos the actor topology a future spike-based advisor will slot into, gives consumers a real producer to wire against today.
- **What's designed but not yet built** — `SpikingEmotionalAdvisor`, `LTCSignatureExtractor`, `SignatureCorrelator`, `MoodTracker`, cross-modal advisors.
- **Failure modes and mitigations** — false-positive floods, cue storms, leak prevention via the Mouth Tool, advisor disagreement, language/cultural lexicon gaps.
- **Privacy** — cues are internal signals; user-facing output goes through the Mouth Tool.

### `lib/src/commonMain/kotlin/io/github/solaceharmony/core/mood/`

| File | Role |
|---|---|
| `Emotion.kt` | Enum class with JOY, CALM, CURIOSITY, FRUSTRATION, ANGER, SADNESS, FEAR, SURPRISE, NEUTRAL. Each entry carries a lower-case `label` for prompt-prime construction. Companion exposes `ALL_NON_NEUTRAL` for advisor scoring loops. |
| `MoodCue.kt` | Data class: `correlationId`, `timestamp`, `source`, `emotion`, `intensity`, `confidence`, optional `promptSuggestion`, optional `evidence`. Range-checks `intensity` and `confidence` in `[0, 1]` in `init`. |
| `MoodSignature.kt` | Interface for the affective fingerprint the spike/LTC layers will produce. `dimensions: Int`, `correlate(other): Float`. Shipped now so consumers can program against it before the implementations land. |
| `EmotionalAdvisor.kt` | Abstract `Actor` base. Owns input port `userText` (String) and output port `cues` (MoodCue). Subclasses implement `suspend fun analyze(text: String): MoodCue?`. |
| `Lexicon.kt` | Pluggable keyword/regex map: `Map<Emotion, List<WeightedPattern>>`, plus a `Lexicon.fromKeywords` convenience that compiles plain strings as case-insensitive regexes with weight 1.0. |
| `LexicalEmotionalAdvisor.kt` | Concrete advisor scoring emotions by weighted regex matches against a `Lexicon`. Computes intensity as winner-share of total score and confidence as winner-runner-up margin. Configurable `confidenceThreshold` (default 0.4) and `maxEvidenceFragments` (default 5). Ships with a small English-only `DEFAULT_LEXICON`. |

### `lib/src/jvmTest/.../mood/LexicalEmotionalAdvisorTest.kt`

11 tests, all pass:

- Blank input returns null.
- No-lexicon-match input returns null.
- Frustration / Joy / Sadness / Fear detection across distinct lexical patterns.
- Prompt suggestion accompanies non-neutral non-calm emotions.
- Low-confidence input below threshold returns null (tests the silence-over-low-confidence design choice).
- Evidence is omitted when `maxEvidenceFragments=0` (production deployments).
- Evidence is bounded by `maxEvidenceFragments`.
- Custom lexicon overrides default.
- Intensity normalises to `1.0` when one category dominates.

## Implementation notes

- **Why an enum, not `sealed class` with `data object` subclasses.** First draft used `sealed class Emotion` with `data object Joy : Emotion()` etc. and a companion `ALL_NON_NEUTRAL: List<Emotion>` listing them. On Kotlin 2.2.20 the data-object instances accessed through the companion list were not `==` (or `===`) equal to direct references like `Emotion.Joy` — a sealed-class + data-object + companion-init-order quirk that broke `Map<Emotion, _>` lookups. A plain `enum class` avoids the issue and is the cleaner shape for discrete categories anyway.

- **Why ship a lexical advisor at all.** It is intentionally simple. Lexical sentiment classification misses sarcasm, negation, cultural variance, etc. It ships not because it's the right long-term answer but because the cue protocol needs to be exercisable end-to-end before the spike + liquid layers land. When a stronger advisor lands, it slots into the same actor graph with no consumer changes.

- **Range-checking in `init`.** `MoodCue` enforces `intensity in [0, 1]` and `confidence in [0, 1]` at construction time. A misbehaving advisor cannot poison Reflection Memory with out-of-range cues that retrieval consumers would have to defend against.

## Net diff

```
8 files changed, 622 insertions(+)
```

## Test plan

- [x] `:lib:compileCommonMainKotlinMetadata` succeeds.
- [x] `:lib:jvmTest --tests "io.github.solaceharmony.core.mood.*"` — all 11 tests pass.
- [ ] CI passes across all targets.
